### PR TITLE
Initial implementation of merge workflow

### DIFF
--- a/.github/workflows/gbp-merge-and-lp-upload.yaml
+++ b/.github/workflows/gbp-merge-and-lp-upload.yaml
@@ -1,0 +1,53 @@
+name: GBP Merge and LP Upload
+on:
+  workflow_call:
+    inputs:
+      target-branch:
+        type: string
+        default: ubuntu/master
+      source:
+        type: string
+        default: debian/master
+      series:
+        type: string
+        default: jammy
+      repo:
+        type: string
+        required: true
+  workflow_dispatch:
+    inputs:
+      target-branch:
+        type: string
+        default: ubuntu/master
+      source:
+        type: string
+        default: debian/master
+      series:
+        type: string
+        default: jammy
+      repo:
+        type: string
+        required: true
+
+jobs:
+  gbp-merge:
+    uses: ./.github/workflows/gbp-merge.yaml
+    secrets: inherit
+    with:
+      repo: ${{ inputs.repo }}
+      target-branch: ${{ inputs.target-branch }}
+      source: ${{ inputs.source }}
+  gbp-build:
+    uses: ./.github/workflows/gbp-build.yaml
+    needs: [gbp-merge]
+    secrets: inherit
+    with:
+      repo: ${{ inputs.repo }}
+      branch: ${{ inputs.target-branch }}
+      series: ${{ inputs.series }}
+  lp-upload:
+    uses: ./.github/workflows/lp-upload.yaml
+    needs: [gbp-build]
+    secrets: inherit
+    with:
+      ppa: testing

--- a/.github/workflows/gbp-merge-and-lp-upload.yaml
+++ b/.github/workflows/gbp-merge-and-lp-upload.yaml
@@ -1,19 +1,5 @@
 name: GBP Merge and LP Upload
 on:
-  workflow_call:
-    inputs:
-      target-branch:
-        type: string
-        default: ubuntu/master
-      source:
-        type: string
-        default: debian/master
-      series:
-        type: string
-        default: jammy
-      repo:
-        type: string
-        required: true
   workflow_dispatch:
     inputs:
       target-branch:

--- a/.github/workflows/gbp-merge.yaml
+++ b/.github/workflows/gbp-merge.yaml
@@ -1,0 +1,81 @@
+name: GBP Merge
+on:
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: 'Git Repo URL to clone'
+        type: string
+        required: true
+      target-branch:
+        description: 'Branch to merge into'
+        type: string
+        default: ubuntu/master
+      source:
+        description: 'Git source branch or tag to merge from'
+        type: string
+        default: debian/master
+  workflow_call:
+    inputs:
+      repo:
+        description: 'Git Repo URL to clone'
+        type: string
+        required: true
+      target-branch:
+        description: 'Branch to merge into'
+        type: string
+        default: ubuntu/master
+      source:
+        description: 'Branch to merge from'
+        type: string
+        default: debian/master
+
+env:
+  DEBEMAIL: ${{ secrets.LP_EMAIL }}
+
+jobs:
+  merge-source-to-target:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git git-buildpackage
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PUB_KEY }}" > ~/.ssh/id_rsa.pub
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          echo "${{ secrets.KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          chmod 400 ~/.ssh/id_rsa
+      - name: Clone Repository
+        run: |
+          git clone ${{ inputs.repo }} project
+          cd project
+          git config user.email ${{ secrets.LP_EMAIL }}
+          git config user.name "${{ secrets.LP_USER }}"
+      - name: Merge Source Into Target Branch
+        run: |
+          cd project
+          git checkout ${{ inputs.target-branch }}
+          git merge ${{ inputs.source }}
+      - name: Rebase Patches
+        run: |
+          cd project
+          gbp pq import
+          gbp pq export
+          git add debian
+          git commit -m "Rebase patches" || true
+      - name: Update Changelog
+        run: |
+          gbp dch
+          git add debian
+          git commit -m "Update changelog" || true
+      - name: Push Branch
+        run: git push origin ${{ inputs.target-branch }}
+      - name: Clean Up
+        if: always()
+        run: |
+          rm -rf ~/.ssh
+      


### PR DESCRIPTION
Add two new workflows, gbp-merge and gbp-merge-and-lp-upload. GBP merge is a reusable workflow that merges a source branch/tag into a target branch with a gbp-specific workflow.  This can be used stand-alone or with the complete merge and upload workflow.  The full workflow also incorporates the reusable build workflow and uploads those artifacts directly to the launchpad ppa

Both workflows accept the following inputs:
- repo
- target-branch
- source

gbp-merge-and-lp-upload also supports:
- series

The workflows also require the following secrets:
- LP_USER
- LP_EMAIL
- SSH_PUB_KEY
- SSH_PRIVATE_KEY
- KNOWN_HOSTS